### PR TITLE
Add Vultr commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ To list EC2 instances under your account:
 
 `gcloudbill` - Shows your GCP bill.
 
+### Vultr (`vultr`)
+
+`vultr_list` - Lists vultr server instances.
+
+`vultr_reboot` - Reboot Vultr server instance.
+
+`vultr_snap` - Create a snapshot of Vultr server instance.
+
 ### Billing (`billing`)
 
 `awsbill` - Shows your AWS bill.

--- a/command_sets.yaml
+++ b/command_sets.yaml
@@ -20,6 +20,9 @@ command_sets:
   aws:
     sourcePath: https://raw.githubusercontent.com/nimbella/command-sets/master/aws/commands.yaml
     description: AWS commands.
+  vultr:
+    sourcePath: https://raw.githubusercontent.com/nimbella/command-sets/master/vultr/commands.yaml
+    description: Vultr commands.
   dig:
     sourcePath: https://raw.githubusercontent.com/nimbella/command-sets/master/dig/commands.yaml
     description: Command to lookup DNS

--- a/vultr/commands.yaml
+++ b/vultr/commands.yaml
@@ -3,3 +3,8 @@ commands:
   vultr_list:
     sourcePath: /vultr_list.js
     description: Lists Vultr server instances.
+  vultr_reboot:
+    sourcePath: /vultr_reboot.js
+    description: Reboot Vultr server instance.
+    parameters:
+      - name: subid

--- a/vultr/commands.yaml
+++ b/vultr/commands.yaml
@@ -8,3 +8,8 @@ commands:
     description: Reboot Vultr server instance.
     parameters:
       - name: subid
+  vultr_snap:
+    sourcePath: /vultr_snap.js
+    description: Create a snapshot of Vultr server instance.
+    parameters:
+      - name: subid

--- a/vultr/commands.yaml
+++ b/vultr/commands.yaml
@@ -1,0 +1,5 @@
+sourceBasePath: https://raw.githubusercontent.com/nimbella/command-sets/master/vultr/src
+commands:
+  vultr_list:
+    sourcePath: /vultr_list.js
+    description: Lists Vultr server instances.

--- a/vultr/src/vultr_list.js
+++ b/vultr/src/vultr_list.js
@@ -38,7 +38,7 @@ async function _command(params, commandText, secrets = {}) {
     };
   }
 
-  const {__slack_headers: clientHeaders} = params;
+  const {__client_headers: clientHeaders} = params;
   const getClient = () => {
     if (clientHeaders['user-agent'].includes('Slackbot')) {
       return 'slack';

--- a/vultr/src/vultr_list.js
+++ b/vultr/src/vultr_list.js
@@ -22,23 +22,6 @@ const mui = (element, client) => {
   return output.join(' ');
 };
 
-// To enable the platform to cache the module when possible.
-let Vultr;
-
-/**
- * Install NPM packages.
- * @param {string} pkgName - The name of the package to be installed.
- */
-async function install(pkgName) {
-  return new Promise((resolve, reject) => {
-    const {exec} = require('child_process');
-    exec(`npm install ${pkgName}`, (err, stdout, stderr) => {
-      if (err) reject(err);
-      else resolve();
-    });
-  });
-}
-
 /**
  * @description Says "Hello, world!" or "Hello, <name>" when the name is provided.
  * @param {ParamsType} params list of command parameters
@@ -70,10 +53,7 @@ async function _command(params, commandText, secrets = {}) {
   const result = [];
 
   try {
-    if (!Vultr) {
-      await install('@vultr/vultr-node');
-      Vultr = require('@vultr/vultr-node');
-    }
+    const Vultr = require('@vultr/vultr-node');
 
     const {server} = Vultr.initialize({apiKey: vultrApiKey});
 

--- a/vultr/src/vultr_list.js
+++ b/vultr/src/vultr_list.js
@@ -6,17 +6,17 @@
  * @param {string} client - name of the client
  */
 const mui = (element, client) => {
-  const output = [];
   if (client === 'slack') {
     return element;
-  } else {
-    if (element.type === 'context') {
-      for (const item of element.elements) {
-        output.push(item.text.replace(/\*/g, '**'));
-      }
-    } else if (element.type === 'section') {
-      output.push(element.text.text.replace(/\*/g, '**'));
+  }
+
+  const output = [];
+  if (element.type === 'context') {
+    for (const item of element.elements) {
+      output.push(item.text.replace(/\*/g, '**'));
     }
+  } else if (element.type === 'section') {
+    output.push(element.text.text.replace(/\*/g, '**'));
   }
 
   return output.join(' ');

--- a/vultr/src/vultr_list.js
+++ b/vultr/src/vultr_list.js
@@ -1,0 +1,67 @@
+'use strict';
+
+/**
+ * @description Says "Hello, world!" or "Hello, <name>" when the name is provided.
+ * @param {ParamsType} params list of command parameters
+ * @param {?string} commandText text message
+ * @param {!object} [secrets = {}] list of secrets
+ * @return {Promise<SlackBodyType>} Response body
+ */
+async function _command(params, commandText, secrets = {}) {
+  const {vultrApiKey} = secrets;
+  if (!vultrApiKey) {
+    return {
+      text:
+        'You need `vultrApiKey` secret to run this command. Create one by running `/nc secret_create`.'
+    };
+  }
+
+  // This array is used to store slack blocks.
+  const result = [];
+  const Vultr = require('@vultr/vultr-node');
+
+  const {server} = Vultr.initialize({apiKey: vultrApiKey});
+
+  const data = await server.list();
+  for (const key of Object.keys(data)) {
+    const {main_ip, status, label} = data[key];
+    result.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `ID: ${key}`
+        },
+        {
+          type: 'mrkdwn',
+          text: `IP: \`${main_ip}\``
+        },
+        {
+          type: 'mrkdwn',
+          text: `Status: *${status}*`
+        },
+        {
+          type: 'mrkdwn',
+          text: `${label}`
+        }
+      ]
+    });
+  }
+
+  return {
+    // Or `ephemeral` for private response
+    response_type: 'in_channel', // eslint-disable-line camelcase
+    blocks: result
+  };
+}
+
+/**
+ * @typedef {object} SlackBodyType
+ * @property {string} text
+ * @property {'in_channel'|'ephemeral'} [response_type]
+ */
+
+const main = async ({__secrets = {}, commandText, ...params}) => ({
+  body: await _command(params, commandText, __secrets)
+});
+module.exports = main;

--- a/vultr/src/vultr_list.js
+++ b/vultr/src/vultr_list.js
@@ -1,5 +1,27 @@
 'use strict';
 
+/**
+ * A small function that converts slack elements `context` and `section` to mattermost compatible markdown.
+ * @param {object} element - Slack element
+ * @param {string} client - name of the client
+ */
+const mui = (element, client) => {
+  const output = [];
+  if (client === 'slack') {
+    return element;
+  } else {
+    if (element.type === 'context') {
+      for (const item of element.elements) {
+        output.push(item.text.replace(/\*/g, '**'));
+      }
+    } else if (element.type === 'section') {
+      output.push(element.text.text.replace(/\*/g, '**'));
+    }
+  }
+
+  return output.join(' ');
+};
+
 // To enable the platform to cache the module when possible.
 let Vultr;
 
@@ -33,6 +55,17 @@ async function _command(params, commandText, secrets = {}) {
     };
   }
 
+  const {__slack_headers: clientHeaders} = params;
+  const getClient = () => {
+    if (clientHeaders['user-agent'].includes('Slackbot')) {
+      return 'slack';
+    }
+
+    return 'mattermost';
+  };
+
+  const client = getClient();
+
   // This array is used to store slack blocks.
   const result = [];
 
@@ -47,42 +80,53 @@ async function _command(params, commandText, secrets = {}) {
     const data = await server.list();
     for (const [key, value] of Object.entries(data)) {
       const {main_ip, status, label} = value;
-      result.push({
-        type: 'context',
-        elements: [
+      result.push(
+        mui(
           {
-            type: 'mrkdwn',
-            text: `ID: ${key}`
+            type: 'context',
+            elements: [
+              {
+                type: 'mrkdwn',
+                text: `ID: ${key}`
+              },
+              {
+                type: 'mrkdwn',
+                text: `IP: \`${main_ip}\``
+              },
+              {
+                type: 'mrkdwn',
+                text: `Status: *${status}*`
+              },
+              {
+                type: 'mrkdwn',
+                text: `${label}`
+              }
+            ]
           },
-          {
-            type: 'mrkdwn',
-            text: `IP: \`${main_ip}\``
-          },
-          {
-            type: 'mrkdwn',
-            text: `Status: *${status}*`
-          },
-          {
-            type: 'mrkdwn',
-            text: `${label}`
-          }
-        ]
-      });
+          client
+        )
+      );
     }
   } catch (error) {
-    result.push({
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: `*Error*: ${error.message}`
-      }
-    });
+    result.push(
+      mui(
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*Error*: ${error.message}`
+          }
+        },
+        client
+      )
+    );
   }
 
   return {
     // Or `ephemeral` for private response
     response_type: 'in_channel', // eslint-disable-line camelcase
-    blocks: result
+    [client === 'slack' ? 'blocks' : 'text']:
+      client === 'slack' ? result : result.join('\n')
   };
 }
 

--- a/vultr/src/vultr_list.js
+++ b/vultr/src/vultr_list.js
@@ -38,16 +38,8 @@ async function _command(params, commandText, secrets = {}) {
     };
   }
 
-  const {__client_headers: clientHeaders} = params;
-  const getClient = () => {
-    if (clientHeaders['user-agent'].includes('Slackbot')) {
-      return 'slack';
-    }
-
-    return 'mattermost';
-  };
-
-  const client = getClient();
+  const {__client} = params;
+  const client = __client.name;
 
   // This array is used to store slack blocks.
   const result = [];

--- a/vultr/src/vultr_reboot.js
+++ b/vultr/src/vultr_reboot.js
@@ -38,16 +38,8 @@ async function _command(params, commandText, secrets = {}) {
     };
   }
 
-  const {subid, __client_headers: clientHeaders} = params;
-  const getClient = () => {
-    if (clientHeaders['user-agent'].includes('Slackbot')) {
-      return 'slack';
-    }
-
-    return 'mattermost';
-  };
-
-  const client = getClient();
+  const {subid, __client} = params;
+  const client = __client.name;
 
   // This array is used to store slack blocks.
   const result = [];

--- a/vultr/src/vultr_reboot.js
+++ b/vultr/src/vultr_reboot.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * @description Says "Hello, world!" or "Hello, <name>" when the name is provided.
+ * @param {ParamsType} params list of command parameters
+ * @param {?string} commandText text message
+ * @param {!object} [secrets = {}] list of secrets
+ * @return {Promise<SlackBodyType>} Response body
+ */
+async function _command(params, commandText, secrets = {}) {
+  const {vultrApiKey} = secrets;
+  if (!vultrApiKey) {
+    return {
+      text:
+        'You need `vultrApiKey` secret to run this command. Create one by running `/nc secret_create`.'
+    };
+  }
+
+  // This array is used to store slack blocks.
+  const result = [];
+  const {subid} = params;
+
+  const Vultr = require('@vultr/vultr-node');
+
+  const {server} = Vultr.initialize({apiKey: vultrApiKey});
+
+  const data = await server.reboot({SUBID: subid});
+
+  if (typeof data === 'undefined') {
+    result.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `Reboot initiated for \`${subid}\``
+        }
+      ]
+    });
+  }
+
+  return {
+    // Or `ephemeral` for private response
+    response_type: 'in_channel', // eslint-disable-line camelcase
+    blocks: result
+  };
+}
+
+/**
+ * @typedef {object} SlackBodyType
+ * @property {string} text
+ * @property {'in_channel'|'ephemeral'} [response_type]
+ */
+
+const main = async ({__secrets = {}, commandText, ...params}) => ({
+  body: await _command(params, commandText, __secrets)
+});
+module.exports = main;

--- a/vultr/src/vultr_reboot.js
+++ b/vultr/src/vultr_reboot.js
@@ -6,38 +6,21 @@
  * @param {string} client - name of the client
  */
 const mui = (element, client) => {
-  const output = [];
   if (client === 'slack') {
     return element;
-  } else {
-    if (element.type === 'context') {
-      for (const item of element.elements) {
-        output.push(item.text.replace(/\*/g, '**'));
-      }
-    } else if (element.type === 'section') {
-      output.push(element.text.text.replace(/\*/g, '**'));
+  }
+
+  const output = [];
+  if (element.type === 'context') {
+    for (const item of element.elements) {
+      output.push(item.text.replace(/\*/g, '**'));
     }
+  } else if (element.type === 'section') {
+    output.push(element.text.text.replace(/\*/g, '**'));
   }
 
   return output.join(' ');
 };
-
-// To enable the platform to cache the module when possible.
-let Vultr;
-
-/**
- * Install NPM packages.
- * @param {string} pkgName - The name of the package to be installed.
- */
-async function install(pkgName) {
-  return new Promise((resolve, reject) => {
-    const {exec} = require('child_process');
-    exec(`npm install ${pkgName}`, (err, stdout, stderr) => {
-      if (err) reject(err);
-      else resolve();
-    });
-  });
-}
 
 /**
  * @description Says "Hello, world!" or "Hello, <name>" when the name is provided.
@@ -70,10 +53,7 @@ async function _command(params, commandText, secrets = {}) {
   const result = [];
 
   try {
-    if (!Vultr) {
-      await install('@vultr/vultr-node');
-      Vultr = require('@vultr/vultr-node');
-    }
+    const Vultr = require('@vultr/vultr-node');
 
     const {server} = Vultr.initialize({apiKey: vultrApiKey});
 

--- a/vultr/src/vultr_reboot.js
+++ b/vultr/src/vultr_reboot.js
@@ -1,5 +1,22 @@
 'use strict';
 
+// To enable the platform to cache the module when possible.
+let Vultr;
+
+/**
+ * Install NPM packages.
+ * @param {string} pkgName - The name of the package to be installed.
+ */
+async function install(pkgName) {
+  return new Promise((resolve, reject) => {
+    const {exec} = require('child_process');
+    exec(`npm install ${pkgName}`, (err, stdout, stderr) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
 /**
  * @description Says "Hello, world!" or "Hello, <name>" when the name is provided.
  * @param {ParamsType} params list of command parameters
@@ -20,13 +37,16 @@ async function _command(params, commandText, secrets = {}) {
   const result = [];
   const {subid} = params;
 
-  const Vultr = require('@vultr/vultr-node');
+  try {
+    if (!Vultr) {
+      await install('@vultr/vultr-node');
+      Vultr = require('@vultr/vultr-node');
+    }
 
-  const {server} = Vultr.initialize({apiKey: vultrApiKey});
+    const {server} = Vultr.initialize({apiKey: vultrApiKey});
 
-  const data = await server.reboot({SUBID: subid});
+    await server.reboot({SUBID: Number(subid)});
 
-  if (typeof data === 'undefined') {
     result.push({
       type: 'context',
       elements: [
@@ -35,6 +55,14 @@ async function _command(params, commandText, secrets = {}) {
           text: `Reboot initiated for \`${subid}\``
         }
       ]
+    });
+  } catch (error) {
+    result.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Error*: ${error.message}`
+      }
     });
   }
 

--- a/vultr/src/vultr_reboot.js
+++ b/vultr/src/vultr_reboot.js
@@ -38,7 +38,7 @@ async function _command(params, commandText, secrets = {}) {
     };
   }
 
-  const {subid, __slack_headers: clientHeaders} = params;
+  const {subid, __client_headers: clientHeaders} = params;
   const getClient = () => {
     if (clientHeaders['user-agent'].includes('Slackbot')) {
       return 'slack';

--- a/vultr/src/vultr_snap.js
+++ b/vultr/src/vultr_snap.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * @description Says "Hello, world!" or "Hello, <name>" when the name is provided.
+ * @param {ParamsType} params list of command parameters
+ * @param {?string} commandText text message
+ * @param {!object} [secrets = {}] list of secrets
+ * @return {Promise<SlackBodyType>} Response body
+ */
+async function _command(params, commandText, secrets = {}) {
+  const {vultrApiKey} = secrets;
+  if (!vultrApiKey) {
+    return {
+      text:
+        'You need `vultrApiKey` secret to run this command. Create one by running `/nc secret_create`.'
+    };
+  }
+
+  // This array is used to store slack blocks.
+  const result = [];
+  const {subid} = params;
+
+  const Vultr = require('@vultr/vultr-node');
+
+  const {snapshot} = Vultr.initialize({apiKey: vultrApiKey});
+
+  const {SNAPSHOTID} = await snapshot.create({SUBID: subid});
+
+  result.push({
+    type: 'context',
+    elements: [
+      {
+        type: 'mrkdwn',
+        text: `Snapshot with ID \`${SNAPSHOTID}\` is initiated for \`${subid}\``
+      }
+    ]
+  });
+
+  return {
+    // Or `ephemeral` for private response
+    response_type: 'in_channel', // eslint-disable-line camelcase
+    blocks: result
+  };
+}
+
+/**
+ * @typedef {object} SlackBodyType
+ * @property {string} text
+ * @property {'in_channel'|'ephemeral'} [response_type]
+ */
+
+const main = async ({__secrets = {}, commandText, ...params}) => ({
+  body: await _command(params, commandText, __secrets)
+});
+module.exports = main;

--- a/vultr/src/vultr_snap.js
+++ b/vultr/src/vultr_snap.js
@@ -38,16 +38,8 @@ async function _command(params, commandText, secrets = {}) {
     };
   }
 
-  const {subid, __client_headers: clientHeaders} = params;
-  const getClient = () => {
-    if (clientHeaders['user-agent'].includes('Slackbot')) {
-      return 'slack';
-    }
-
-    return 'mattermost';
-  };
-
-  const client = getClient();
+  const {subid, __client} = params;
+  const client = __client.name;
 
   // This array is used to store slack blocks.
   const result = [];

--- a/vultr/src/vultr_snap.js
+++ b/vultr/src/vultr_snap.js
@@ -6,41 +6,24 @@
  * @param {string} client - name of the client
  */
 const mui = (element, client) => {
-  const output = [];
   if (client === 'slack') {
     return element;
-  } else {
-    if (element.type === 'context') {
-      for (const item of element.elements) {
-        output.push(item.text.replace(/\*/g, '**'));
-      }
-    } else if (element.type === 'section') {
-      output.push(element.text.text.replace(/\*/g, '**'));
+  }
+
+  const output = [];
+  if (element.type === 'context') {
+    for (const item of element.elements) {
+      output.push(item.text.replace(/\*/g, '**'));
     }
+  } else if (element.type === 'section') {
+    output.push(element.text.text.replace(/\*/g, '**'));
   }
 
   return output.join(' ');
 };
 
-// To enable the platform to cache the module when possible.
-let Vultr;
-
 /**
- * Install NPM packages.
- * @param {string} pkgName - The name of the package to be installed.
- */
-async function install(pkgName) {
-  return new Promise((resolve, reject) => {
-    const {exec} = require('child_process');
-    exec(`npm install ${pkgName}`, (err, stdout, stderr) => {
-      if (err) reject(err);
-      else resolve();
-    });
-  });
-}
-
-/**
- * @description Says "Hello, world!" or "Hello, <name>" when the name is provided.
+ * @description Take a snapshot of server instance.
  * @param {ParamsType} params list of command parameters
  * @param {?string} commandText text message
  * @param {!object} [secrets = {}] list of secrets
@@ -70,10 +53,7 @@ async function _command(params, commandText, secrets = {}) {
   const result = [];
 
   try {
-    if (!Vultr) {
-      await install('@vultr/vultr-node');
-      Vultr = require('@vultr/vultr-node');
-    }
+    const Vultr = require('@vultr/vultr-node');
 
     const {snapshot} = Vultr.initialize({apiKey: vultrApiKey});
 

--- a/vultr/src/vultr_snap.js
+++ b/vultr/src/vultr_snap.js
@@ -38,7 +38,7 @@ async function _command(params, commandText, secrets = {}) {
     };
   }
 
-  const {subid, __slack_headers: clientHeaders} = params;
+  const {subid, __client_headers: clientHeaders} = params;
   const getClient = () => {
     if (clientHeaders['user-agent'].includes('Slackbot')) {
       return 'slack';

--- a/vultr/src/vultr_snap.js
+++ b/vultr/src/vultr_snap.js
@@ -1,5 +1,27 @@
 'use strict';
 
+/**
+ * A small function that converts slack elements `context` and `section` to mattermost compatible markdown.
+ * @param {object} element - Slack element
+ * @param {string} client - name of the client
+ */
+const mui = (element, client) => {
+  const output = [];
+  if (client === 'slack') {
+    return element;
+  } else {
+    if (element.type === 'context') {
+      for (const item of element.elements) {
+        output.push(item.text.replace(/\*/g, '**'));
+      }
+    } else if (element.type === 'section') {
+      output.push(element.text.text.replace(/\*/g, '**'));
+    }
+  }
+
+  return output.join(' ');
+};
+
 // To enable the platform to cache the module when possible.
 let Vultr;
 
@@ -33,9 +55,19 @@ async function _command(params, commandText, secrets = {}) {
     };
   }
 
+  const {subid, __slack_headers: clientHeaders} = params;
+  const getClient = () => {
+    if (clientHeaders['user-agent'].includes('Slackbot')) {
+      return 'slack';
+    }
+
+    return 'mattermost';
+  };
+
+  const client = getClient();
+
   // This array is used to store slack blocks.
   const result = [];
-  const {subid} = params;
 
   try {
     if (!Vultr) {
@@ -47,29 +79,40 @@ async function _command(params, commandText, secrets = {}) {
 
     const {SNAPSHOTID} = await snapshot.create({SUBID: Number(subid)});
 
-    result.push({
-      type: 'context',
-      elements: [
+    result.push(
+      mui(
         {
-          type: 'mrkdwn',
-          text: `Snapshot with ID \`${SNAPSHOTID}\` is initiated for \`${subid}\``
-        }
-      ]
-    });
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: `Snapshot with ID \`${SNAPSHOTID}\` is initiated for \`${subid}\``
+            }
+          ]
+        },
+        client
+      )
+    );
   } catch (error) {
-    result.push({
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: `*Error*: ${error.message}`
-      }
-    });
+    result.push(
+      mui(
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*Error*: ${error.message}`
+          }
+        },
+        client
+      )
+    );
   }
 
   return {
     // Or `ephemeral` for private response
     response_type: 'in_channel', // eslint-disable-line camelcase
-    blocks: result
+    [client === 'slack' ? 'blocks' : 'text']:
+      client === 'slack' ? result : result.join('\n')
   };
 }
 


### PR DESCRIPTION
This PR adds the following commands:

- `vultr_list`
- `vultr_reboot`
- `vultr_snap`
<img width="451" alt="Screenshot 2020-01-20 at 10 25 28 PM" src="https://user-images.githubusercontent.com/29819102/72745029-cc01d880-3bd4-11ea-8b2c-67e78c5295a1.png">
 
Can be merged once we have `@vultr/vultr-node` installed on the container.