### PR TITLE
[BlueJeans] Make cancellationMessage a required parameter for `bluejeans_cancel`

### DIFF
--- a/bluejeans/README.md
+++ b/bluejeans/README.md
@@ -25,9 +25,9 @@ Where date is in `mm/dd/yy` format and time is in UTC.
 
 To cancel a meeting:
 ```sh
-/dapp bluejeans_cancel <meetingId> [<cancellationMessage>]
+/dapp bluejeans_cancel <meetingId> <cancellationMessage>
 ```
-`meetingId` is required and `cancellationMessage` is optional.
+Both `meetingId` and `cancellationMessage` are required.
 
 To list all meetings of admin:
 ```sh

--- a/bluejeans/commands.yaml
+++ b/bluejeans/commands.yaml
@@ -30,4 +30,3 @@ commands:
     parameters:
       - name: meetingId
       - name: cancellationMessage
-        optional: true

--- a/bluejeans/packages/bluejeans/bluejeans_cancel.js
+++ b/bluejeans/packages/bluejeans/bluejeans_cancel.js
@@ -18,7 +18,7 @@ async function _command(params = {}, commandText, secrets = {}) {
 
   const result = [];
   const baseURL = `https://api.bluejeans.com`;
-  const {meetingId, cancellationMessage = ''} = params;
+  const {meetingId, cancellationMessage} = params;
   const axios = require('axios');
 
   // Fetch access token
@@ -38,11 +38,9 @@ async function _command(params = {}, commandText, secrets = {}) {
 
   // Cancel a meeting
   let requestURL = baseURL + users[0].uri + `/scheduled_meeting/${meetingId}`;
-  requestURL += `?email=true&access_token=${data.access_token}`;
-
-  if (cancellationMessage) {
-    requestURL += `&cancellationMessage=${cancellationMessage}`;
-  }
+  requestURL += `?email=true&cancellationMessage=${encodeURI(
+    cancellationMessage
+  )}&access_token=${data.access_token}`;
 
   const {status} = await axios.delete(requestURL);
   if (status === 200) {

--- a/bluejeans/packages/bluejeans/bluejeans_cancel.js
+++ b/bluejeans/packages/bluejeans/bluejeans_cancel.js
@@ -58,8 +58,12 @@ async function _command(params = {}, commandText, secrets = {}) {
  * @property {string} text
  * @property {'in_channel'|'ephemeral'} [response_type]
  */
-const main = async ({__secrets = {}, commandText, ...params}) => ({
-  body: await _command(params, commandText, __secrets).catch(error => ({
+const main = async args => ({
+  body: await _command(
+    args.params,
+    args.commandText,
+    args.__secrets || {}
+  ).catch(error => ({
     response_type: 'ephemeral',
     text: `Error: ${error.message}`
   }))


### PR DESCRIPTION
A cancellation message is required to cancel a meeting.

Fixes #71 