### PR TITLE
Few improvements to kube_log command

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -85,7 +85,7 @@ By default only 10 items are shown. The command supports pagination so you can s
 Get logs of a pod.
 
 ```sh
-/nc kube_logs <podName> [-n <tailLines>]
+/nc kube_logs <podName> [-n <namespace>] [-l <tailLines>]
 ```
 
 By default last 25 lines of logs are shown which you can modify the number of lines per request using `-n` flag.

--- a/kubernetes/commands.yaml
+++ b/kubernetes/commands.yaml
@@ -2,8 +2,10 @@ commands:
   kube_logs:
     description: Get logs of a pod.
     options:
-      - name: n
+      - name: l
         value: tailLines
+      - name: n
+        value: namespace
     parameters:
       - name: podName
   kube_get:

--- a/kubernetes/packages/kubernetes/kube_logs.js
+++ b/kubernetes/packages/kubernetes/kube_logs.js
@@ -14,16 +14,16 @@ async function _command(params, commandText, secrets = {}) {
       response_type: 'ephemeral',
       text:
         `Secrets named \`K8S_SERVER\`, \`K8S_TOKEN\`, and \`K8S_CA\` are required to run this Command Set. ` +
-        `Read <https://github.com/satyarohith/command-sets/tree/k8/kubernetes#requirements|this> to learn more.`
+        `Read <https://github.com/nimbella/command-sets/tree/master/kubernetes#requirements|this> to learn more.`
     };
   }
 
-  const {podName, tailLines = 25} = params;
+  const {podName, tailLines = 25, namespace = 'default'} = params;
 
   const https = require('https');
   const axios = require('axios');
   const {data} = await axios.get(
-    `${K8S_SERVER}/api/v1/namespaces/default/pods/${podName}/log?tailLines=${tailLines}`,
+    `${K8S_SERVER}/api/v1/namespaces/${namespace}/pods/${podName}/log?tailLines=${tailLines}`,
     {
       httpsAgent: new https.Agent({
         ca: Buffer.from(K8S_CA, 'base64')


### PR DESCRIPTION
- use `-l` for to specify the number of log lines. 
- use `-n` to specify the namespace. 