### PR TITLE
Add support for Mattermost in GitHub Command Set

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -1,19 +1,27 @@
 # Nimbella Commander GitHub Command Set
 
-A Nimbella Commander command set for interfacing with GitHub
+Interact with GitHub from messaging platforms like Slack, Mattermost & Microsoft Teams using [Nimbella Commander](https://nimbella.com/product/commander).
+
+- [Features](#Features)
+- [Installation](#Installation)
+- [Requirements](#Requirements)
+- [Commands](#Commands)
+- [Usage](#Usage)
+- [Support](#support)
 
 ## Features
 
-- Create an issue
-- Close an issue
-- Reopen an issue
-- Label an issue/pull request
-- Request someone to review a pull request
-- View repository community statistics
-- Searching repositories, commits, code, issues, pull requests, users and topics using given words
-- View GitHub command set documentation
+- Create an issue.
+- Close an issue.
+- Reopen an issue.
+- Label an issue/pull request.
+- Request someone to review a pull request.
+- View repository community statistics.
+- Searching repositories, commits, code, issues, pull requests, users and topics using given words.
 
-## Install
+## Installation
+
+Please make sure Commander is installed in your [Slack workspace](https://slack.com/apps/AS833QXL0-nimbella-commander) or [other messaging platforms](../README.md#installation) before executing this Slash command.
 
 ```
 /nc csm_install github
@@ -21,9 +29,9 @@ A Nimbella Commander command set for interfacing with GitHub
 
 ## Requirements
 
-In order to use this command set, you need to set up a Personal Access Token on GitHub with repo access. And save the token as a secret with the key 'github_token'
-Use `/nc secret_create` to create secrets.
-Visit https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line to learn how to setup a Personal Access Token on GitHub
+In order to use this command set, you need to set up a Personal Access Token on GitHub with repo access. And save the token as a secret with `github_token` as the key name. Use `/nc secret_create` to create secrets.
+
+Visit [this page](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) to learn how to setup a Personal Access Token on GitHub.
 
 Create a secret named `github_repos` to avoid passing repository (`-r`) to commands.
 
@@ -31,81 +39,133 @@ Create a secret named `github_repos` to avoid passing repository (`-r`) to comma
 
 For commands that only work with single repository the first repository in `github_repos` is used.
 
+## Commands
+
+- [`github`](#github) - View GitHub command set documentation.
+- [`github_close_issue`](#github_close_issue) - Close an issue.
+- [`github_create_issue`](#github_create_issue) - Create an issue.
+- [`github_find_pr`](#github_find_pr) - Find pull requests by last update date.
+- [`github_label`](#github_label) - Label an issue/pull request.
+- [`github_reopen_issue`](#github_reopen_issue) - Reopen an issue.
+- [`github_request_review`](#github_request_review) - Request someone to review a pull request.
+- [`github_search`](#github_search) - Search repositories, commits, code, issues, pull requests, users and topics using keywords.
+- [`github_stats`](#github_stats) - View repository community statistics.
+- [`github_view_pr`](#github_view_pr) - View recent pull requests.
+
 ## Usage
 
-**Note:** The repository (-r) flag should include both owner name and repository name. Example: `-r nimbella/command-sets`
+### [`github`](https://github.com/nimbella/command-sets/blob/master/github/packages/github/github.js)
 
-Creating an issue.
+View GitHub command set documentation
 
+```sh
+/nc github
 ```
-/nc github_create_issue <title> <body> [-r <repository>]
-```
 
-![GitHub create_issue command](https://raw.githubusercontent.com/nimbella/command-sets/master/github/screenshots/create_issue.png)
+### [`github_close_issue`](https://github.com/nimbella/command-sets/blob/master/github/packages/github/github_close_issue.js)
 
-Closing an issue.
+Close an issue.
 
-```
-/nc github_close_issue <issue_number> [-r <repository>]
+```sh
+/nc github_close_issue <issueNumber> [-r <repo>]
 ```
 
 ![GitHub close_issue command](https://raw.githubusercontent.com/nimbella/command-sets/master/github/screenshots/close_issue.png)
 
-Reopening an issue
+### [`github_create_issue`](https://github.com/nimbella/command-sets/blob/master/github/packages/github/github_create_issue.js)
 
+Create an issue.
+
+```sh
+/nc github_create_issue <title> <body> [-r <repo>]
 ```
-/nc github_reopen_issue <issue_number> [-r <repository>]
+
+![GitHub create_issue command](https://raw.githubusercontent.com/nimbella/command-sets/master/github/screenshots/create_issue.png)
+
+### [`github_find_pr`](https://github.com/nimbella/command-sets/blob/master/github/packages/github/github_find_pr.js)
+
+Find pull requests by last update date.
+
+```sh
+/nc github_find_pr <date> [-r <repo>] [-state <state>]
 ```
 
-![GitHub reopen_issue command](https://raw.githubusercontent.com/nimbella/command-sets/master/github/screenshots/reopen_issue.png)
+### [`github_label`](https://github.com/nimbella/command-sets/blob/master/github/packages/github/github_label.js)
 
-Labeling an issue.
+Label an issue/pull request.
 
-```
-/nc github_label <issueNumber> <labels> [-r <repository>]
+```sh
+/nc github_label <issueNumber> <labels> [-r <repo>]
 ```
 
 ![GitHub label command](https://raw.githubusercontent.com/nimbella/command-sets/master/github/screenshots/label.png)
 
-Getting repository statistics
+### [`github_reopen_issue`](https://github.com/nimbella/command-sets/blob/master/github/packages/github/github_reopen_issue.js)
 
+Reopen an issue.
+
+```sh
+/nc github_reopen_issue <issueNumber> [-r <repo>]
 ```
-/nc github_stats [<repository>]
+
+![GitHub reopen_issue command](https://raw.githubusercontent.com/nimbella/command-sets/master/github/screenshots/reopen_issue.png)
+
+### [`github_request_review`](https://github.com/nimbella/command-sets/blob/master/github/packages/github/github_request_review.js)
+
+Request someone to review a pull request
+
+```sh
+/nc github_request_review <prNumber> <reviewers> [-r <repo>]
 ```
 
-![GitHub stats command](https://raw.githubusercontent.com/nimbella/command-sets/master/github/screenshots/stats.png)
+### [`github_search`](https://github.com/nimbella/command-sets/blob/master/github/packages/github/github_search.js)
 
+Search repositories, commits, code, issues, pull requests, users and topics using keywords.
 
-Finding repositories, commits, code, issues, pull requests, users and topics using keywords
-
-```
-/nc github_search <entity> <keywords> [-q <query>] [-r <repositories>] [-l <language>] [-s <pageSize>] [-n <pageNumber>]
+```sh
+/nc github_search <entity> [<keywords>] [-q <query>] [-r <repositories>] [-l <language>] [-s <pageSize>] [-n <pageNumber>]
 ```
 
 ![GitHub search command](https://raw.githubusercontent.com/nimbella/command-sets/master/github/screenshots/search.png)
 
 Entity can be passed in as an abbreviation:
 
-- r - repositories
-- cm - commits
-- c - code
-- i - issues
-- p - pull requests
-- u - users
-- t - topics
+- `r` - repositories
+- `cm` - commits
+- `c` - code
+- `i` - issues
+- `p` - pull requests
+- `u` - users
+- `t` - topics
 
 Multiple keywords can be combined using `+` sign. e.g. `atom+design`
 
-Optionally following options can be provided for more specific search 
+Optionally the following options can be provided for more specific search.
 
-- [-q <query>] query can be formed using [github search syntax](https://help.github.com/en/github/searching-for-information-on-github/understanding-the-search-syntax)
-- [-r <repositories>] specific repositories can be given e.g. `-r microsoft/vscode,nimbella/command-sets`. In order to avoid having to type in repository names every time command needs to run, default repositories can be specified using `\nc secret_create` ![](https://raw.githubusercontent.com/nimbella/command-sets/master/github/screenshots/secret_creator.png)   
-- [-l <language>] specific language can be mentioned e.g. `-l python`
-- [-s <pageSize>] number of records to be fetched in one go e.g. `-s 10`
-- [-n <pageNumber>] next set of records can be fetched using e.g. `-n 2`
+- `[-q <query>]` query can be formed using [github search syntax](https://help.github.com/en/github/searching-for-information-on-github/understanding-the-search-syntax).
+- `[-r <repositories>]` specific repositories can be given (e.g. `-r microsoft/vscode,nimbella/command-sets`).
+- `[-l <language>]` specific language can be mentioned (e.g. `-l python`).
+- `[-s <pageSize>]` number of records to be fetched in one go (e.g. `-s 10`).
+- `[-n <pageNumber>]` next set of records can be fetched using (e.g. `-n 2`).
 
-Viewing GitHub command set documentation
+### [`github_stats`](https://github.com/nimbella/command-sets/blob/master/github/packages/github/github_stats.js)
 
+View repository community statistics.
+
+```sh
+/nc github_stats [<repo>]
 ```
-/nc github
+
+![GitHub stats command](https://raw.githubusercontent.com/nimbella/command-sets/master/github/screenshots/stats.png)
+
+### [`github_view_pr`](https://github.com/nimbella/command-sets/blob/master/github/packages/github/github_view_pr.js)
+
+View recent pull requests.
+
+```sh
+/nc github_view_pr [<repo>] [-state <state>]
 ```
+
+## Support
+
+We're always happy to help you with any issues you encounter. You may want to [join our Slack community](https://nimbella-community.slack.com/) to engage with us for a more rapid response.

--- a/github/README.md
+++ b/github/README.md
@@ -120,6 +120,8 @@ Request someone to review a pull request
 
 ### [`github_search`](https://github.com/nimbella/command-sets/blob/master/github/packages/github/github_search.js)
 
+> **Note:** Mattermost support for this command is yet to be added.
+
 Search repositories, commits, code, issues, pull requests, users and topics using keywords.
 
 ```sh

--- a/github/packages/github/github.js
+++ b/github/packages/github/github.js
@@ -1,6 +1,47 @@
 // jshint esversion: 9
 
 /**
+ * A small function that converts slack elements `context` and `section` to mattermost compatible markdown.
+ * @param {object} element - Slack element
+ * @param {string} client - name of the client
+ */
+const mui = (element, client) => {
+  if (client !== 'mattermost') {
+    return element;
+  }
+
+  const output = [];
+  switch (element.type) {
+    case 'context': {
+      for (const item of element.elements) {
+        output.push(item.text.replace(/\*/g, '**'));
+      }
+      break;
+    }
+    case 'section': {
+      if (element.fields && element.fields.length > 0) {
+        for (const field of element.fields) {
+          output.push(field.text.replace(/\*/g, '**') + '\n');
+        }
+      } else if (element.text) {
+        // Convert single text element to h4 in mattermost.
+        output.push('#### ' + element.text.text.replace(/\*/g, '**'));
+      }
+      break;
+    }
+    case 'divider': {
+      output.push('***');
+      break;
+    }
+    case 'image': {
+      output.push(`![${element.title.alt_text}](${element.image_url})`);
+    }
+  }
+
+  return output.join(' ');
+};
+
+/**
  * @description View GitHub command set documentation
  * @param {ParamsType} params list of command parameters
  * @param {?string} commandText text message
@@ -11,104 +52,149 @@ async function _command(params, commandText, secrets = {}) {
   const baseUrl =
     'https://raw.githubusercontent.com/nimbella/command-sets/master/github/screenshots';
 
-  const image = (source, alt) => ({
-    type: 'image',
-    title: {
-      type: 'plain_text',
-      text: alt,
-      emoji: true
-    },
-    image_url: source,
-    alt_text: alt
-  });
+  const client = params.__client ? params.__client.name : 'slack';
 
-  const section = text => ({
-    type: 'section',
-    text: {
-      type: 'mrkdwn',
-      text
-    }
-  });
+  const image = (source, alt) => {
+    return {
+      type: 'image',
+      title: {
+        type: 'plain_text',
+        text: alt,
+        emoji: true
+      },
+      image_url: source,
+      alt_text: alt
+    };
+  };
 
-  return {
-    response_type: 'in_channel',
-    blocks: [
+  const section = text => {
+    return {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text
+      }
+    };
+  };
+
+  const result = [
+    mui(
       section(
         'Nimbella Commander GitHub Command Set.\
-      \n_A Nimbella Commander command set for interfacing with GitHub._\
-      \n\n*Features*:\
-      \n• Create an issue\
-      \n• Close an issue\
-      \n• Reopen an issue\
-      \n• Label an issue/pull request\
-      \n• Request someone to review a pull request\
-      \n• View repository community statistics\
-      \n• Search repositories, commits, code, issues, pull requests, users, topics matching given words\
-      \n• View GitHub command set documentation\
-      \n\n*Requirements*:\
-      \nSet up a Personal Access Token on GitHub with repo access.\
-      \nSave the token as a secret with the key `github_token`\
-      \nCreate secrets using.\
-      \n `/nc secret_create`\
-      \n<https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line|Click> to learn how to setup a Personal Access Token on GitHub\
-      \n\n\n*Usage*:'
+    \n_A Nimbella Commander command set for interfacing with GitHub._\
+    \n\n*Features*:\
+    \n• Create an issue\
+    \n• Close an issue\
+    \n• Reopen an issue\
+    \n• Label an issue/pull request\
+    \n• Request someone to review a pull request\
+    \n• View repository community statistics\
+    \n• Search repositories, commits, code, issues, pull requests, users, topics matching given words\
+    \n• View GitHub command set documentation\
+    \n\n*Requirements*:\
+    \nSet up a Personal Access Token on GitHub with repo access.\
+    \nSave the token as a secret with the key `github_token`\
+    \nCreate secrets using.\
+    \n `/nc secret_create`\
+    \n<https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line|Click> to learn how to setup a Personal Access Token on GitHub\
+    \n\n\n*Usage*:'
       ),
-      //
+      client
+    ),
+    //
+    mui(
       section(
         '*Creating an issue:* \n`/nc github_create_issue <repo> <title> <body>`'
       ),
+      client
+    ),
+    mui(
       image(`${baseUrl}/create_issue.png`, 'github create issue command'),
-      //
+      client
+    ),
+    //
+    mui(
       section(
         '*Closing an issue:* \n`/nc github_close_issue <repo> <issue_number>`'
       ),
+      client
+    ),
+    mui(
       image(`${baseUrl}/close_issue.png`, 'github close issue command'),
-
+      client
+    ),
+    mui(
       section(
         '*Reopening an issue:* \n`/nc github_reopen_issue <repo> <issue_number>`'
       ),
+      client
+    ),
+    mui(
       image(`${baseUrl}/reopen_issue.png`, 'github reopen issue command'),
-      //
+      client
+    ),
+    //
+    mui(
       section(
         '*Labeling an issue or pull request:* \n`/nc github_label <repo> <number> <labels>`'
       ),
-      image(`${baseUrl}/label.png`, 'github label command'),
-      //
+      client
+    ),
+    mui(image(`${baseUrl}/label.png`, 'github label command'), client),
+    //
+    mui(
       section('*Getting repository statistics:* \n`/nc github_stats <repo>`'),
-      image(`${baseUrl}/stats.png`, 'github stats command'),
-      //
-      section('*Searching repositories, commits, code, issues, pull requests, users and topics using keywords:* \n`/nc github_search <entity> <keywords> [-q <query>] [-r <repositories>] [-l <language>] [-s <pageSize>] [-n <pageNumber>]`\nEntity can be passed in as an abbreviation:\
-      \n r  - repositories\
-      \n cm - commits\
-      \n c  - code \
-      \n i  - issues\
-      \n p  - pull requests\
-      \n u  - users \
-      \n t  - topics\
-      \nMultiple search words can be combined using `+` sign. e.g. `atom+design`\
-      \n\nOptionally following options can be provided for more specific search\
-      \n- [-q <query>] query can be formed using <https://help.github.com/en/github/searching-for-information-on-github/understanding-the-search-syntax | github search syntax>\. In order to avoid having to type in repository names every time command needs to run, default repositories can be specified using `\\nc secret_create`\
-      \n- [-r <repositories>] specific repositories can be given e.g. `-r microsoft/vscode,nimbella/command-sets`\
-      \n- [-l <language>] specific language can be mentioned e.g. `-l python`\
-      \n- [-s <pageSize>] number of records to be fetched in one go e.g. `-s 10`\
-      \n- [-n <pageNumber>] next set of records can be fetched using e.g. `-n 2`\
-      '),
-      image(`${baseUrl}/search.png`, 'github search command'),
-      //
+      client
+    ),
+    mui(image(`${baseUrl}/stats.png`, 'github stats command'), client),
+    //
+    mui(
+      section(
+        '*Searching repositories, commits, code, issues, pull requests, users and topics using keywords:* \n`/nc github_search <entity> <keywords> [-q <query>] [-r <repositories>] [-l <language>] [-s <pageSize>] [-n <pageNumber>]`\nEntity can be passed in as an abbreviation:\
+    \n r  - repositories\
+    \n cm - commits\
+    \n c  - code \
+    \n i  - issues\
+    \n p  - pull requests\
+    \n u  - users \
+    \n t  - topics\
+    \nMultiple search words can be combined using `+` sign. e.g. `atom+design`\
+    \n\nOptionally following options can be provided for more specific search\
+    \n- [-q <query>] query can be formed using <https://help.github.com/en/github/searching-for-information-on-github/understanding-the-search-syntax | github search syntax>. In order to avoid having to type in repository names every time command needs to run, default repositories can be specified using `\\nc secret_create`\
+    \n- [-r <repositories>] specific repositories can be given e.g. `-r microsoft/vscode,nimbella/command-sets`\
+    \n- [-l <language>] specific language can be mentioned e.g. `-l python`\
+    \n- [-s <pageSize>] number of records to be fetched in one go e.g. `-s 10`\
+    \n- [-n <pageNumber>] next set of records can be fetched using e.g. `-n 2`\
+    '
+      ),
+      client
+    ),
+    mui(image(`${baseUrl}/search.png`, 'github search command'), client),
+    //
+    mui(
       {
         type: 'divider'
       },
+      client
+    ),
+    mui(
       {
         type: 'context',
         elements: [
           {
             type: 'mrkdwn',
-            text:
-              '❓Get help on these commands with `/nc github`'
+            text: '❓Get help on these commands with `/nc github`'
           }
         ]
-      }
-    ]
+      },
+      client
+    )
+  ];
+
+  return {
+    response_type: 'in_channel',
+    [client !== 'mattermost' ? 'blocks' : 'text']:
+      client !== 'mattermost' ? result : result.join('\n')
   };
 }
 

--- a/github/packages/github/github_close_issue.js
+++ b/github/packages/github/github_close_issue.js
@@ -8,7 +8,7 @@
  * @return {Promise<SlackBodyType>} Response body
  */
 async function _command(params, commandText, secrets = {}) {
-  let {github_token: githubToken, github_repos: defaultRepo} = secrets;
+  let {github_token: githubToken, github_repos: defaultRepo = ''} = secrets;
   if (!githubToken) {
     return {
       response_type: 'ephemeral',

--- a/github/packages/github/github_close_issue.js
+++ b/github/packages/github/github_close_issue.js
@@ -27,7 +27,7 @@ async function _command(params, commandText, secrets = {}) {
     return {
       response_type: 'ephemeral',
       text:
-        'Either pass a repo name or create a secret named `github_default_repo` to avoid passing the repository.'
+        'Either pass a repo name or create a secret named `github_repos` to avoid passing the repository.'
     };
   }
 

--- a/github/packages/github/github_create_issue.js
+++ b/github/packages/github/github_create_issue.js
@@ -8,7 +8,7 @@
  * @return {Promise<SlackBodyType>} Response body
  */
 async function _command(params, commandText, secrets = {}) {
-  let {github_token: githubToken, github_repos: defaultRepo} = secrets;
+  let {github_token: githubToken, github_repos: defaultRepo = ''} = secrets;
   if (!githubToken) {
     return {
       response_type: 'ephemeral',

--- a/github/packages/github/github_create_issue.js
+++ b/github/packages/github/github_create_issue.js
@@ -27,7 +27,7 @@ async function _command(params, commandText, secrets = {}) {
     return {
       response_type: 'ephemeral',
       text:
-        'Either pass a repo name or create a secret named `github_default_repo` to avoid passing the repository.'
+        'Either pass a repo name or create a secret named `github_repos` to avoid passing the repository.'
     };
   }
 

--- a/github/packages/github/github_label.js
+++ b/github/packages/github/github_label.js
@@ -8,7 +8,7 @@
  * @return {Promise<SlackBodyType>} Response body
  */
 async function _command(params, commandText, secrets = {}) {
-  let {github_token: githubToken, github_repos: defaultRepo} = secrets;
+  let {github_token: githubToken, github_repos: defaultRepo = ''} = secrets;
   if (!githubToken) {
     return {
       response_type: 'ephemeral',

--- a/github/packages/github/github_label.js
+++ b/github/packages/github/github_label.js
@@ -27,7 +27,7 @@ async function _command(params, commandText, secrets = {}) {
     return {
       response_type: 'ephemeral',
       text:
-        'Either pass a repo name or create a secret named `github_default_repo` to avoid passing the repository.'
+        'Either pass a repo name or create a secret named `github_repos` to avoid passing the repository.'
     };
   }
 

--- a/github/packages/github/github_reopen_issue.js
+++ b/github/packages/github/github_reopen_issue.js
@@ -8,7 +8,7 @@
  * @return {Promise<SlackBodyType>} Response body
  */
 async function _command(params, commandText, secrets = {}) {
-  let {github_token: githubToken, github_repos: defaultRepo} = secrets;
+  let {github_token: githubToken, github_repos: defaultRepo = ''} = secrets;
   if (!githubToken) {
     return {
       response_type: 'ephemeral',

--- a/github/packages/github/github_reopen_issue.js
+++ b/github/packages/github/github_reopen_issue.js
@@ -27,7 +27,7 @@ async function _command(params, commandText, secrets = {}) {
     return {
       response_type: 'ephemeral',
       text:
-        'Either pass a repo name or create a secret named `github_default_repo` to avoid passing the repository.'
+        'Either pass a repo name or create a secret named `github_repos` to avoid passing the repository.'
     };
   }
 

--- a/github/packages/github/github_request_review.js
+++ b/github/packages/github/github_request_review.js
@@ -8,7 +8,7 @@
  * @return {Promise<SlackBodyType>} Response body
  */
 async function _command(params, commandText, secrets = {}) {
-  let {github_token: githubToken, github_repos: defaultRepo} = secrets;
+  let {github_token: githubToken, github_repos: defaultRepo = ''} = secrets;
   if (!githubToken) {
     return {
       response_type: 'ephemeral',

--- a/github/packages/github/github_request_review.js
+++ b/github/packages/github/github_request_review.js
@@ -27,7 +27,7 @@ async function _command(params, commandText, secrets = {}) {
     return {
       response_type: 'ephemeral',
       text:
-        'Either pass a repo name or create a secret named `github_default_repo` to avoid passing the repository.'
+        'Either pass a repo name or create a secret named `github_repos` to avoid passing the repository.'
     };
   }
 

--- a/github/packages/github/github_stats.js
+++ b/github/packages/github/github_stats.js
@@ -15,7 +15,7 @@ async function _command(params, commandText, secrets = {}) {
     return {
       response_type: 'ephemeral',
       text:
-        'Either pass a repo name or create a secret named `github_default_repo` to avoid passing the repository.'
+        'Either pass a repo name or create a secret named `github_repos` to avoid passing the repository.'
     };
   }
 

--- a/github/packages/github/github_stats.js
+++ b/github/packages/github/github_stats.js
@@ -22,7 +22,7 @@ async function _command(params, commandText, secrets = {}) {
   githubRepos = githubRepos.split(',').map(repo => repo.trim());
 
   const result = [];
-
+  const client = params.__client.name;
   const tokenMessage = githubToken
     ? ''
     : 'For greater limits, create a secret named `github_token` with a <https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line|GitHub token> using `/nc secret_create`.';
@@ -64,7 +64,10 @@ async function _command(params, commandText, secrets = {}) {
       result.push({
         color: 'good',
         text: body.join('\n'),
-        title: `<${data.html_url}|${data.full_name}> statistics`,
+        title:
+          client === 'mattermost'
+            ? `[${data.full_name}](${data.html_url})`
+            : `<${data.html_url}|${data.full_name}> statistics`,
         pretext:
           currReading < requestThreshold
             ? `:warning: *You are about to reach the api rate limit.* ${tokenMessage}`
@@ -80,7 +83,10 @@ async function _command(params, commandText, secrets = {}) {
     } else if (error.response && error.response.status === 404) {
       result.push({
         color: 'danger',
-        text: `Repository not found: <https://github.com/${repo}|${repo}>.`
+        text:
+          client === 'mattermost'
+            ? `Repository not found: [${repo}](https://github.com/${repo})`
+            : `Repository not found: <https://github.com/${repo}|${repo}>.`
       });
     } else if (error.response && error.response.status) {
       result.push({

--- a/github/packages/github/github_view_pr.js
+++ b/github/packages/github/github_view_pr.js
@@ -16,7 +16,7 @@ async function _command(params, commandText, secrets = {}) {
     return {
       response_type: 'ephemeral',
       text:
-        'Either pass a repo name or create a secret named `github_default_repo` to avoid passing the repository.'
+        'Either pass a repo name or create a secret named `github_repos` to avoid passing the repository.'
     };
   }
 

--- a/github/packages/github/github_view_pr.js
+++ b/github/packages/github/github_view_pr.js
@@ -65,11 +65,8 @@ async function _command(params, commandText, secrets = {}) {
 
       // Matches <>
       const html = new RegExp(/<.*>/);
-      for (
-        let i = 0;
-        i < (data.length > 3 && githubRepos.length > 1 ? 3 : data.length);
-        i++
-      ) {
+      // Show 5 recent PRs.
+      for (let i = 0; i < (data.length > 5 ? 5 : data.length); i++) {
         const pr = data[i];
         const body = html.test(pr.body)
           ? `_couldn't render body of pr_`


### PR DESCRIPTION
- [x]  `github`
- [x]  `github_create_issue`
- [x]  `github_close_issue`
- [x]  `github_reopen_issue`
- [x]  `github_label`
- [x]  `github_request_review`
- [x]  `github_stats`
- [x]  `github_view_pr`

This will be tackled by @bhageena: 
- [ ]  `github_search`

Readme preview: https://github.com/satyarohith/command-sets/tree/github-mattermost/github#nimbella-commander-github-command-set